### PR TITLE
makefile tweak for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 #OBUILDOPTS="--debug+"
 PACKAGE_NAME=websocket
 
+FINDLIB_SUFFIXES := cmi cmx cma cmxa o a
+
 .PHONY: clean uninstall
 
 all: dist/setup/lib-$(PACKAGE_NAME)
@@ -13,7 +15,7 @@ dist/setup/lib-$(PACKAGE_NAME): dist/setup
 
 install: dist/setup/lib-$(PACKAGE_NAME)
 	ocamlfind remove $(PACKAGE_NAME)
-	ocamlfind install $(PACKAGE_NAME) dist/build/lib-$(PACKAGE_NAME)/$(PACKAGE_NAME).{cmi,cmx,cma,cmxa,o,a} lib/META
+	ocamlfind install $(PACKAGE_NAME) $(addprefix dist/build/lib-$(PACKAGE_NAME)/$(PACKAGE_NAME)., $(FINDLIB_SUFFIXES)) lib/META
 
 clean:
 	obuild clean


### PR DESCRIPTION
make install did not actually work for me with zsh. I think because of the brace expansion (it would not be expanded). I've made a fix to use pure make and not rely on any bashisms. 
