### PR TITLE
Set Makefile shell to /bin/bash to support brace expansion in the install target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 #OBUILDOPTS="--debug+"
 PACKAGE_NAME=websocket
+SHELL=bash
 
 .PHONY: clean uninstall
 


### PR DESCRIPTION
Without this change installation fails with:

```
ocamlfind: dist/build/lib-websocket/websocket.{cmi,cmx,cma,cmxa,o,a}: No such file or directory
```
