### PR TITLE
Modify open to accept extra headers that will be sent to the server.  Th...

### DIFF
--- a/lib/websocket.mli
+++ b/lib/websocket.mli
@@ -56,14 +56,14 @@ module Frame : sig
   (** Frame creation *)
 end
 
-val open_connection : ?tls:bool -> Uri.t ->
+val open_connection : ?tls:bool -> ?extra_headers:((string * string) list) -> Uri.t ->
   (Frame.t Lwt_stream.t * (Frame.t option -> unit)) Lwt.t
 (** [open_connection ~tls uri] will open a connection (over TLS if
     [~tls] is [true]) to the given uri, and return a stream and a push
     function that can be used to send and receive websocket
     messages. *)
 
-val with_connection : ?tls:bool -> Uri.t ->
+val with_connection : ?tls:bool -> ?extra_headers:((string * string) list) -> Uri.t ->
   (Frame.t Lwt_stream.t * (Frame.t option -> unit) -> 'a Lwt.t) -> 'a Lwt.t
 (** Same as above except for here you provide a function that will be
     in charge of communicating with the other end, and that takes a


### PR DESCRIPTION
Hi,

Thanks very much for writing (and sharing) your websockets code!  I'm using it in a project I've been working on to get to know OCaml.  Unfortunately, the web server I'm connecting to wants some additional headers on the original HTTP request.  

This patch adds the ability to pass a list of additional headers to the server at connection establishment.  Accomplishing this seemed pretty straightforward except in the case of a collision between the additional headers and the headers that the websockets module uses.  I don't think this case should ever crop up in reality, but I had to handle it somehow so I let the additional headers overwrite the module's.

I hope you like the patch.  I'd be happy to revise it in any way you'd like.

Thanks
Andy
