### PR TITLE
Fixed writer error

### DIFF
--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -320,7 +320,7 @@ let open_connection ?tls_authenticator ?(extra_headers = []) uri =
          catch
            (fun () ->
               Lwt_unix.handle_unix_error
-                (fun () -> CU.Request.write (fun _ _ -> return_unit) req oc) () >>= fun () ->
+                (fun () -> CU.Request.write (fun _ -> Lwt.return_unit) req oc) () >>= fun () ->
               Lwt_unix.handle_unix_error CU.Response.read ic >>= (function
                   | `Ok r -> return r
                   | `Eof -> fail End_of_file
@@ -402,7 +402,7 @@ let establish_server ?certificate ?buffer_size ?backlog sockaddr f =
         ~status:`Switching_protocols
         ~encoding:C.Transfer.Unknown
         ~headers:response_headers () in
-    CU.Response.write (fun _ _ -> Lwt.return_unit) response oc >>= fun () ->
+    CU.Response.write (fun _ -> Lwt.return_unit) response oc >>= fun () ->
     Lwt.pick [read_frames (ic,oc) push_in push_out;
               send_frames ~masked:false stream_out (ic,oc);
               f uri (stream_in, push_out)]


### PR DESCRIPTION
Alright,

I'm still kinda new to OCaml, but I hope I'll be able to save you some time. I wrote this little program to test your library with Cohttp 0.12.0 and my fix to your version 0.9.

```ocaml
open Core.Std
open Lwt
open Websocket


try_lwt (
	Tls_lwt.rng_init ()
	>>= fun () ->
		let () = print_endline "abc" in
		return ()
	>>= fun () ->
		let () = print_endline "def" in
		Websocket.open_connection (Uri.of_string "http://127.0.0.1:4000")
	>>= fun (stream, push) ->
		let () = print_endline "ghi" in
		return ()
) with
| End_of_file -> return (print_endline "eof!!")
| x -> Exn.to_string x |> fun s -> s^"!!!!!" |> print_endline |> return
```

When connecting to a simple socket.io server, it crashes right away with End_of_file and never prints "ghi" (yes, I'm using blocking print statements intentionally for this test). Maybe there's a bug in my test, but if there isn't, then I hope this will help you narrow it down!

Thanks!