### PR TITLE
Do not use getsockopt to verify result of setsockopt

### DIFF
--- a/lib/lwt_io_ext.ml
+++ b/lib/lwt_io_ext.ml
@@ -102,6 +102,4 @@ let sockaddr_of_dns node service =
   >|= fun ai -> ai.ai_addr
 
 let set_tcp_nodelay fd =
-  Lwt_unix.setsockopt fd Lwt_unix.TCP_NODELAY true;
-  if not (Lwt_unix.getsockopt fd Lwt_unix.TCP_NODELAY)
-  then failwith "Unable to set TCP_NODELAY"
+  Lwt_unix.setsockopt fd Lwt_unix.TCP_NODELAY true


### PR DESCRIPTION
This is broken in OCaml on some platforms (ocaml/ocaml#143) and so
the tcp_nodelay check causes websocket to fail entirely on those
platforms (MacOS X being one of them).

Debugged with @andrewray 