### PR TITLE
Signal socket close to client prior to logging.

### DIFF
--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -205,8 +205,9 @@ let read_frames (ic,oc) push_to_client push_to_remote =
   let rec read_forever () =
     (try%lwt read_frame ()
      with exn ->
+       (try push_to_client None with _ -> ());
        Lwt_log.debug ~section ~exn "read_frame" >>= fun () ->
-       (try push_to_client None with _ -> ()); fail exn)
+       fail exn)
     >>= fun () -> read_forever () in
   read_forever ()
 


### PR DESCRIPTION
For some odd reason, the client will not receive the close
signal if it is sent after the log call. Even stranger, it
does not work without the log call, and the LWT_LOG env var
must be set to something printable, eg LWT_LOG="*->debug".

Test case: https://gist.github.com/j0sh/71c31743d4057a6f365f
Connect and disconnect (any) client; if it is working, then "user disconnected" should print.

This isn't really a fix, but hopefully helps illustrate the problem -- if the solution isn't obvious from this, I can start looking within Lwt.