### PR TITLE
Skip close code when pushing contents to client.

### DIFF
--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -198,7 +198,7 @@ let read_frames (ic,oc) push_to_client push_to_remote =
                                    content 2 (payload_len - 2)))
          else
            (push_to_remote (Some (Frame.of_bytes ~opcode:Opcode.Close ()));
-            push_to_client (Some (Frame.of_bytes ~opcode ~extension ~final ~content ())))
+            push_to_client (Some (Frame.of_bytes ~opcode ~extension ~final ())))
         );
         raise Close_frame_received
       | _ ->


### PR DESCRIPTION
Propagating the close code to the client via the payload is not
allowed according to RFC6455 Section 5.5.1.

Instead, the returned close code can be checked with the
Close_status opcode.