### PR TITLE
Fix compatibility with tls 0.5

### DIFF
--- a/tests/wscat.ml
+++ b/tests/wscat.ml
@@ -46,7 +46,7 @@ let _ =
   Arg.parse speclist anon_fun usage_msg;
 
   let main () =
-    Tls_lwt.rng_init () >>= fun () ->
+    Nocrypto_entropy_lwt.initialize () >>= fun () ->
     match !server_port, !endpoint_address with
     | p, "" when p <> "" ->
       begin


### PR DESCRIPTION
Tls_lwt.rng_init has been moved to Nocrypto_entropy_lwt.initialize

Could you also make a release with this on opam? Currently wscat gets built
when you do $ opam install websocket so it ends up breaking on latest tls.
Which ends up breaking iocaml for me unfortunately.