### PR TITLE
don't use websocket from findlib .merlin

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,4 +1,3 @@
-PKG websocket
 S lib
 S tests
 B _build/lib


### PR DESCRIPTION
There's no point as the source and build directive cover this.