### PR TITLE
Make server handler take a Cohttp.Request.t rather than Uri.t

### DIFF
--- a/lib/websocket_lwt.ml
+++ b/lib/websocket_lwt.ml
@@ -83,7 +83,6 @@ let establish_server ?timeout ?stop ~ctx ~mode react =
         Lwt.fail @@ Failure reason) >>= fun request ->
     let meth    = C.Request.meth request in
     let version = C.Request.version request in
-    let uri     = C.Request.uri request in
     let headers = C.Request.headers request in
     if not (
         version = `HTTP_1_1
@@ -108,7 +107,7 @@ let establish_server ?timeout ?stop ~ctx ~mode react =
     CU.Response.write (fun writer -> Lwt.return_unit) response oc >>= fun () ->
     let send_frame = send_frame ~masked:false oc in
     let read_frame = make_read_frame ~masked:false (ic, oc) in
-    react id uri read_frame send_frame
+    react id request read_frame send_frame
   in
   Lwt.async_exception_hook :=
     (fun exn -> Lwt_log.ign_warning ~section ~exn "async_exn_hook");

--- a/lib/websocket_lwt.mli
+++ b/lib/websocket_lwt.mli
@@ -68,6 +68,6 @@ val establish_server :
   ctx:Conduit_lwt_unix.ctx ->
   mode:Conduit_lwt_unix.server ->
   (int ->
-   Uri.t ->
+   Cohttp.Request.t ->
    (unit -> Frame.t Lwt.t) -> (Frame.t -> unit Lwt.t) -> unit Lwt.t) ->
   unit Lwt.t

--- a/tests/reynir.ml
+++ b/tests/reynir.ml
@@ -4,7 +4,7 @@ open Lwt.Infix
 let h = Hashtbl.create 17
 let section = Lwt_log.Section.make "reynir"
 
-let handler id uri recv send =
+let handler id req recv send =
   (try
      Hashtbl.find h id
    with Not_found ->

--- a/tests/wscat.ml
+++ b/tests/wscat.ml
@@ -41,7 +41,7 @@ let client uri =
   in pushf () <?> react_forever ()
 
 let server uri =
-  let echo_fun id uri recv send =
+  let echo_fun id req recv send =
     let open Frame in
     let react fr =
       match fr.opcode with


### PR DESCRIPTION
This way more useful information can be extracted from the request data, such as headers.