### PR TITLE
Changes

### DIFF
--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: bin_annot, debug, safe_string, warn(-40), warn_error(+8)
+true: bin_annot, debug, safe_string, warn(-40), warn_error(A-26-39-32-27-45-52-58)
 
 <lib>: include
 <tests>: include

--- a/_tags
+++ b/_tags
@@ -1,4 +1,4 @@
-true: bin_annot, debug, safe_string, warn(-40)
+true: bin_annot, debug, safe_string, warn(-40), warn_error(+8)
 
 <lib>: include
 <tests>: include

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -114,7 +114,7 @@ let upgrade_present hs =
   Cohttp.Header.get_multi hs "connection" |> fun hs ->
   List.map (CCString.Split.list_cpy ~by:",") hs |> fun hs ->
   List.flatten hs |> fun hs ->
-  List.map String.(fun h -> h |> lowercase |> trim) hs |>
+  List.map String.(fun h -> h |> lowercase_ascii |> trim) hs |>
   List.mem "upgrade"
 
 module IO(IO: Cohttp.S.IO) = struct

--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -174,7 +174,7 @@ module IO(IO: Cohttp.S.IO) = struct
     in
     fun () ->
       read ic 2 >>= fun hdr ->
-      if hdr = "" then return (`Error "EOF")
+      if hdr = "" then return `Eof
       else
       let hdr_part1 = EndianString.BigEndian.get_int8 hdr 0 in
       let hdr_part2 = EndianString.BigEndian.get_int8 hdr 1 in

--- a/lib/websocket_async.ml
+++ b/lib/websocket_async.ml
@@ -73,6 +73,7 @@ let client
         try_with begin
           fun () -> read_frame () >>= function
             | `Error msg -> failwith msg
+            | `Eof -> failwith "EOF"
             | `Ok fr ->
               Pipe.write ws_to_app fr
         end >>= function
@@ -223,7 +224,7 @@ let server ?log ?(name="") ?g ~app_to_ws ~ws_to_app ~reader ~writer address =
   let read_frame = make_read_frame ?g ~masked:true (reader, writer) in
   let rec loop () =
     read_frame () >>= function
-    | `Error "EOF" -> Deferred.unit
+    | `Eof -> Deferred.unit
     | `Error msg -> failwith msg
     | `Ok fr -> Pipe.write ws_to_app fr >>= loop
   in

--- a/lib/websocket_cohttp_lwt.ml
+++ b/lib/websocket_cohttp_lwt.ml
@@ -18,6 +18,7 @@ let read_frames ?g icoc handler_fn =
       match%lwt rf with
       | `Ok frame -> Lwt.return frame
       | `Error msg -> Lwt.fail_with msg
+      | `Eof -> Lwt.fail_with "EOF"
     in
     while%lwt true do
       read_frame () >>= Lwt.wrap1 handler_fn

--- a/lib/websocket_lwt.ml
+++ b/lib/websocket_lwt.ml
@@ -64,6 +64,7 @@ let with_connection ?(extra_headers = Cohttp.Header.init ()) ?g ~ctx client uri 
        read_frame () >>= function
        | `Ok frame -> Lwt.return frame
        | `Error msg -> Lwt.fail_with msg
+       | `Eof -> Lwt.fail_with "EOF"
      with exn -> Lwt.fail exn),
   (fun frame ->
      try%lwt
@@ -121,6 +122,7 @@ let establish_server ?timeout ?stop ?g ~ctx ~mode react =
       read_frame () >>= function
       | `Ok frame -> Lwt.return frame
       | `Error msg -> Lwt.fail_with msg
+      | `Eof  -> Lwt.fail_with "EOF"
     in
     react id request read_frame send_frame
   in

--- a/lib/websocket_lwt.ml
+++ b/lib/websocket_lwt.ml
@@ -39,7 +39,7 @@ let with_connection ?(extra_headers = Cohttp.Header.init ()) ?g ~ctx client uri 
       then Lwt.fail @@ HTTP_Error C.Code.(string_of_status status)
       else if not (C.Response.version response = `HTTP_1_1
                    && status = `Switching_protocols
-                   && CCOpt.map String.lowercase @@
+                   && CCOpt.map String.lowercase_ascii @@
                    C.Header.get headers "upgrade" = Some "websocket"
                    && upgrade_present headers
                    && C.Header.get headers "sec-websocket-accept" =
@@ -94,7 +94,7 @@ let establish_server ?timeout ?stop ?g ~ctx ~mode react =
     if not (
         version = `HTTP_1_1
         && meth = `GET
-        && CCOpt.map String.lowercase @@
+        && CCOpt.map String.lowercase_ascii @@
         C.Header.get headers "upgrade" = Some "websocket"
         && upgrade_present headers
       )


### PR DESCRIPTION
I also got rid of deprecation warnings (`String.lowercase` -> `String.lowercase_ascii`), so the changes are not backwards-compatible with 4.02. Is that okay?