### PR TITLE
Don't install tests, update OCaml version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PKG=websocket
 PREFIX=`opam config var prefix`
-BUILDOPTS=native=true native-dynlink=true lwt=true async=true async_ssl=true nocrypto=true cryptokit=true
+BUILDOPTS=native=true native-dynlink=true lwt=true async=true async_ssl=true nocrypto=true cryptokit=true test=true
 
 all: build
 

--- a/opam
+++ b/opam
@@ -38,4 +38,4 @@ conflicts: [
   "nocrypto" {< "0.5.0"}
 ]
 
-available: [ ocaml-version >="4.02.0" ]
+available: [ ocaml-version >="4.03.0" ]

--- a/opam
+++ b/opam
@@ -19,6 +19,7 @@ build: [
                           "async_ssl=%{async_ssl:installed}%"
                           "nocrypto=%{nocrypto:installed}%"
                           "cryptokit=%{cryptokit:installed}%"
+                          "test=false"
   ]
 ]
 depends: [
@@ -30,7 +31,7 @@ depends: [
   "conduit" {>= "0.8.3"}
 ]
 
-depopts: ["async" "async_ssl" {test} "lwt" "nocrypto" "cryptokit"]
+depopts: ["async" "async_ssl" "lwt" "nocrypto" "cryptokit"]
 conflicts: [
   "lwt" {< "2.4.8"}
   "async" {< "112.35.00"}

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -10,6 +10,7 @@ let async = Env.bool "async"
 let async_ssl = Env.bool "async_ssl"
 let nocrypto = Env.bool "nocrypto"
 let cryptokit = Env.bool "cryptokit"
+let test = Env.bool "test"
 
 let ocamlbuild = "ocamlbuild -use-ocamlfind -classic-display -plugin-tag 'package(cppo_ocamlbuild)'"
 
@@ -86,9 +87,9 @@ let () =
     Pkg.lib ~exts:Exts.module_library "lib/rng";
     Pkg.lib ~cond:lwt ~exts:Exts.module_library "lib/websocket_lwt";
     Pkg.lib ~cond:async ~exts:Exts.module_library "lib/websocket_async";
-    Pkg.bin ~cond:lwt ~auto:true "tests/wscat";
-    Pkg.bin ~cond:(async && async_ssl) ~auto:true "tests/wscat_async";
-    Pkg.bin ~cond:lwt ~auto:true "tests/reynir";
-    Pkg.bin ~cond:lwt ~auto:true "tests/upgrade_connection";
-    Pkg.bin ~auto:true "tests/randomstring";
+    Pkg.bin ~cond:(test && lwt) ~auto:true "tests/wscat";
+    Pkg.bin ~cond:(test && async && async_ssl) ~auto:true "tests/wscat_async";
+    Pkg.bin ~cond:(test && lwt) ~auto:true "tests/reynir";
+    Pkg.bin ~cond:(test && lwt) ~auto:true "tests/upgrade_connection";
+    Pkg.bin ~cond:test ~auto:true "tests/randomstring";
   ]


### PR DESCRIPTION
Misc fixes to opam.

Most of these tests should not really be installed by default, so they are disabled here for OPAM builds. (We can leverage the opam test facility if we add a `build-test` field to the opam file, but I didn't bother here.) Building via Makefile still builds tests though.

Also, with 39938fb, OCaml 4.03.0 is required, so update opam accordingly.