### PR TITLE
Perf improvement: Avoid generating xor mask if it isn't used

### DIFF
--- a/lib/websocket.ml
+++ b/lib/websocket.ml
@@ -150,7 +150,6 @@ module IO(IO: Cohttp.S.IO) = struct
   let write_frame_to_buf ?(random_string=Rng.std ?state:None) ~masked buf fr =
     let scratch = Bytes.create 8 in
     let open Frame in
-    let mask = random_string 4 in
     let content = Bytes.unsafe_of_string fr.content in
     let len = Bytes.length content in
     let opcode = Opcode.to_enum fr.opcode in
@@ -175,6 +174,7 @@ module IO(IO: Cohttp.S.IO) = struct
        Buffer.add_subbytes buf scratch 0 8;
     end;
     if masked then begin
+      let mask = random_string 4 in
       Buffer.add_string buf mask;
       if len > 0 then xor mask content;
     end;

--- a/lib/websocket_lwt.ml
+++ b/lib/websocket_lwt.ml
@@ -163,7 +163,7 @@ let with_connection ?(extra_headers = Cohttp.Header.init ())
   let read_frame = make_read_frame ~random_string ~masked:true (ic, oc) in
   let read_frame () = Lwt.catch read_frame (fun exn -> Lwt.fail exn) in
   let buf = Buffer.create 128 in
-  (fun () -> Lwt.catch read_frame (fun exn -> Lwt.fail exn)),
+  read_frame,
   (fun frame ->
      try%lwt
        Buffer.clear buf;


### PR DESCRIPTION
And don't wrap read_frame twice