### PR TITLE
Expose websocket_cohttp_lwt.

### DIFF
--- a/lib/websocket_cohttp_lwt.ml
+++ b/lib/websocket_cohttp_lwt.ml
@@ -15,7 +15,7 @@
  *
  *)
 
-open Websocket
+include Websocket
 
 module C = Cohttp
 module Lwt_IO = Websocket.IO(Cohttp_lwt_unix_io)

--- a/lib/websocket_cohttp_lwt.mli
+++ b/lib/websocket_cohttp_lwt.mli
@@ -15,9 +15,11 @@
  *
  *)
 
+module Frame : module type of Websocket.Frame
+
 val upgrade_connection:
   ?random_string:Rng.t ->
   Cohttp.Request.t ->
   Conduit_lwt_unix.flow ->
-  (Websocket.Frame.t -> unit) ->
-  (Cohttp.Response.t * Cohttp_lwt_body.t * (Websocket.Frame.t option -> unit)) Lwt.t
+  (Frame.t -> unit) ->
+  (Cohttp.Response.t * Cohttp_lwt_body.t * (Frame.t option -> unit)) Lwt.t

--- a/opam
+++ b/opam
@@ -7,13 +7,17 @@ homepage: "https://github.com/vbmithr/ocaml-websocket"
 bug-reports: "https://github.com/vbmithr/ocaml-websocket/issues"
 dev-repo: "git://github.com/vbmithr/ocaml-websocket"
 
+available: [
+  ocaml-version >= "4.02.0"
+]
+
 tags: [
   "org:mirage"
   "org:xapi-project"
 ]
 build: [
-  ["ocaml" "pkg/build.ml" "native=%{ocaml:native}%"
-                          "native-dynlink=%{ocaml:native-dynlink}%"
+  ["ocaml" "pkg/build.ml" "native=%{ocaml-native}%"
+                          "native-dynlink=%{ocaml-native-dynlink}%"
                           "lwt=%{lwt:installed}%"
                           "async=%{async:installed}%"
                           "async_ssl=%{async_ssl:installed}%"
@@ -23,7 +27,6 @@ build: [
   ]
 ]
 depends: [
-  "ocaml" {>= "4.02.0"}
   "cppo" {build}
   "cohttp" {>= "0.17.1"}
   "ocplib-endian" {>= "0.8"}

--- a/pkg/META.template
+++ b/pkg/META.template
@@ -16,6 +16,16 @@ package "lwt" (
   archive(native, plugin) = "websocket_lwt.cmxs"
   exists_if = "websocket_lwt.cma"
 )
+package "cohttp" (
+  version = "%%VERSION%%"
+  description = "Websocket library, for cohttp/lwt upgrades"
+  requires = "websocket cohttp.lwt %%LWT_REQ%%"
+  archive(byte) = "websocket_cohttp_lwt.cma"
+  archive(byte, plugin) = "websocket_cohttp_lwt.cma"
+  archive(native) = "websocket_cohttp_lwt.cmxa"
+  archive(native, plugin) = "websocket_cohttp_lwt.cmxs"
+  exists_if = "websocket_cohttp_lwt.cma"
+)
 package "async" (
   version = "%%VERSION%%"
   description = "Websocket library, for Async"

--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -86,6 +86,7 @@ let () =
     Pkg.lib ~exts:Exts.(".cmx" :: library) "lib/websocket";
     Pkg.lib ~exts:Exts.module_library "lib/rng";
     Pkg.lib ~cond:lwt ~exts:Exts.module_library "lib/websocket_lwt";
+    Pkg.lib ~cond:lwt ~exts:Exts.module_library "lib/websocket_cohttp_lwt";
     Pkg.lib ~cond:async ~exts:Exts.module_library "lib/websocket_async";
     Pkg.bin ~cond:(test && lwt) ~auto:true "tests/wscat";
     Pkg.bin ~cond:(test && async && async_ssl) ~auto:true "tests/wscat_async";


### PR DESCRIPTION
This should address #63.

This commit adds an additional package, `websocket.cohttp`, which exposes
`websocket_cohttp_lwt.ml` to allow cohttp servers to call
`Websocket_cohttp_lwt.upgrade_connection` to serve websocket connection requests.

The patch also modifies the `websocket_cohttp_lwt` interface to follow a
similar pattern to `websocket_lwt` and `websocket_async`. Before, Frame
didn't seem to be exposed correctly, meaning that the test worked, but I
couldn't find a way to use the API externally.

The upgrade_connection test should now only use externally-available functionality (i.e. no
references to `Websocket` directly). This has allowed me to get this working (via opam pin) with another project which requires this functionality.

(I was a little confused by commit f81c97aef85d60803f1f0b0d18f9a86c5349ddba -- I couldn't seem to get "opam pin" to work with those edits, so I've reverted them here; I'm probably missing something so comments would be appreciated :) )