### PR TITLE
adapt to stdless Core / Async

### DIFF
--- a/lib/websocket_async.ml
+++ b/lib/websocket_async.ml
@@ -17,8 +17,8 @@
 
 include Websocket
 
-open Core.Std
-open Async.Std
+open Core
+open Async
 open Cohttp
 
 module Async_IO = IO(Cohttp_async_io)

--- a/lib/websocket_async.mli
+++ b/lib/websocket_async.mli
@@ -24,8 +24,8 @@
     unframing of messages.
 *)
 
-open Core.Std
-open Async.Std
+open Core
+open Async
 
 module Frame : module type of Websocket.Frame
 

--- a/tests/wscat_async.ml
+++ b/tests/wscat_async.ml
@@ -1,5 +1,5 @@
-open Core.Std
-open Async.Std
+open Core
+open Async
 open Log.Global
 
 module W = Websocket_async


### PR DESCRIPTION
I actually don't expect you to merge this right away, because there's no official release of core and async that includes these changes. But the development version (as exposed in the [janestreet opam overlay](/janestreet/opam-repository)) already needs them to build, because while `Std` still exists, it is now deprecated, and we have warnings-as-errors turned on for this package. I'm using an opam pin to get this working and thought I might as well share the changes I made for that purpose.

Another approach that I'd also consider legitimate would be disabling deprecation-warnings-as-errors for the opam build. I don't immediately know how to do that but if you want me to cook it up I can give it a go.