### PR TITLE
Small improvements

### DIFF
--- a/lwt/websocket_lwt.ml
+++ b/lwt/websocket_lwt.ml
@@ -206,7 +206,7 @@ let establish_server
     ?timeout ?stop
     ?on_exn
     ?(check_request=check_origin_with_host)
-    ~ctx ~mode react =
+    ?(ctx=Conduit_lwt_unix.default_ctx) ~mode react =
   let module C = Cohttp in
   let server_fun flow ic oc =
     (Request.read ic >>= function
@@ -265,7 +265,7 @@ let mk_frame_stream recv =
 let establish_standard_server
     ?read_buf ?write_buf
     ?timeout ?stop
-    ?on_exn ?check_request ~ctx ~mode react =
+    ?on_exn ?check_request ?(ctx=Conduit_lwt_unix.default_ctx) ~mode react =
   let f client =
     react (Connected_client.make_standard client)
   in

--- a/lwt/websocket_lwt.ml
+++ b/lwt/websocket_lwt.ml
@@ -60,6 +60,11 @@ module Connected_client = struct
     write_frame_to_buf ~mode:Server buffer frame;
     Lwt_io.write oc @@ Buffer.contents buffer
 
+  let send_multiple { buffer; oc; _ } frames =
+    Buffer.clear buffer;
+    List.iter (write_frame_to_buf ~mode:Server buffer) frames;
+    Lwt_io.write oc @@ Buffer.contents buffer
+
   let standard_recv t =
     t.read_frame () >>= fun fr ->
     match fr.Frame.opcode with

--- a/lwt/websocket_lwt.mli
+++ b/lwt/websocket_lwt.mli
@@ -76,7 +76,7 @@ val establish_server :
   ?stop:unit Lwt.t ->
   ?on_exn:(exn -> unit) ->
   ?check_request:(Cohttp.Request.t -> bool) ->
-  ctx:Conduit_lwt_unix.ctx ->
+  ?ctx:Conduit_lwt_unix.ctx ->
   mode:Conduit_lwt_unix.server ->
   (Connected_client.t -> unit Lwt.t) ->
   unit Lwt.t
@@ -99,7 +99,7 @@ val establish_standard_server :
   ?stop:unit Lwt.t ->
   ?on_exn:(exn -> unit) ->
   ?check_request:(Cohttp.Request.t -> bool) ->
-  ctx:Conduit_lwt_unix.ctx ->
+  ?ctx:Conduit_lwt_unix.ctx ->
   mode:Conduit_lwt_unix.server ->
   (Connected_client.t -> unit Lwt.t) ->
   unit Lwt.t

--- a/lwt/websocket_lwt.mli
+++ b/lwt/websocket_lwt.mli
@@ -36,6 +36,8 @@ module Connected_client : sig
 
   val send : t -> Websocket.Frame.t -> unit Lwt.t
 
+  val send_multiple : t -> Websocket.Frame.t list -> unit Lwt.t
+
   val recv : t -> Websocket.Frame.t Lwt.t
 
   val http_request : t -> Cohttp.Request.t


### PR DESCRIPTION
Two small improvements:

- Let the conduit context default to `Conduit_lwt_unix.default_ctx`, which is a good default
- Add `Websocket_lwt.Connected_client.send_multiple : t -> Websocket.Frame.t list -> unit Lwt.t`, which is more efficient version of calling `send` multiple times. I use this because I'm broadcasting the same frame to multiple clients and then sending client-specific information in another frame