### PR TITLE
Remove package option from non public executables

### DIFF
--- a/test/jbuild
+++ b/test/jbuild
@@ -1,11 +1,9 @@
 (executable
  ((name reynir)
-  (package websocket-lwt)
-  (modules reynir)
+  (modules (reynir))
   (libraries (websocket-lwt))))
 
 (executable
  ((name upgrade_connection)
-  (package websocket-lwt)
-  (modules upgrade_connection)
+  (modules (upgrade_connection))
   (libraries (websocket-lwt.cohttp))))


### PR DESCRIPTION
you only need to give an exe a package if it will be installed.