### PR TITLE
Fix incompatible types error

### DIFF
--- a/async/websocket_async.mli
+++ b/async/websocket_async.mli
@@ -27,7 +27,7 @@
 open Core
 open Async
 
-module Frame : module type of Websocket.Frame
+module Frame = Websocket.Frame
 
 val client :
   ?log:Log.t ->


### PR DESCRIPTION
This change tells the compiler that `Websocket_async.Frame.t` is the same
type as `Websocket.Frame.t`.  Fixes compilation errors when using the modules
and types interchangeably, e.g., when using `Websocket_async.server` with
`Websocket.Frame.t`.