### PR TITLE
Remove forced async_ssl dependency

### DIFF
--- a/websocket-async.opam
+++ b/websocket-async.opam
@@ -18,6 +18,5 @@ tags: [
 build: [ "jbuilder" "build" "-j" jobs "-p" name "@install" ]
 depends: [
   "websocket" {= "2.10"}
-  "async_ssl" {>= "v0.9.0"}
   "cohttp-async" {>= "0.99.0"}
 ]


### PR DESCRIPTION
async_ssl is a depopt of conduit-async, which handles the case when async_ssl is not installed gracefully (with a runtime error when a tls connection is attempted). This package doesn't use async_ssl directly.

(I want to avoid async_ssl as it forces linking with openssl).