### PR TITLE
async: Add client_connect.

### DIFF
--- a/async/websocket_async.mli
+++ b/async/websocket_async.mli
@@ -52,6 +52,9 @@ val client_ez :
   Writer.t ->
   string Pipe.Reader.t * string Pipe.Writer.t
 
+val client_connect : string -> (string Pipe.Reader.t * string Pipe.Writer.t) Deferred.Or_error.t
+(** [client_connect url] provides an easy way of opening a connection given a websocket URL *)
+
 val server :
   ?name:string ->
   ?check_request:(Cohttp.Request.t -> bool Deferred.t) ->


### PR DESCRIPTION
This provides an easy interface for opening a connection given a
websocket URL.

As a new user of this library I spent hours trying to open a simple connection so I hope this helps make things easier for others.