### PR TITLE
cohttp_lwt: fix bug with not calling conn_closed on fd close.

### DIFF
--- a/lwt/websocket_cohttp_lwt.ml
+++ b/lwt/websocket_cohttp_lwt.ml
@@ -62,7 +62,7 @@ let upgrade_connection request incoming_handler =
   in
   let frames_out_stream, frames_out_fn = Lwt_stream.create () in
   let f ic oc =
-    Lwt.join [
+    Lwt.pick [
       (* input: data from the client is read from the input channel
        * of the tcp connection; pass it to handler function *)
       read_frames ic oc incoming_handler;


### PR DESCRIPTION
When client closes tcp connection its left in `CLOSE_WAIT` state. 
https://github.com/mirage/ocaml-cohttp/blob/master/cohttp-lwt/src/server.ml#L141
Because `io_handler` only stops when  `send_frames` stops too.
So `conn_closed` in cohttp-lwt is not called.