### PR TITLE
Make Conduit_lwt_unix.serve call compatible with newer conduit

### DIFF
--- a/lwt/websocket_lwt_unix.ml
+++ b/lwt/websocket_lwt_unix.ml
@@ -113,7 +113,7 @@ let write_failed_response oc =
 let establish_server
     ?read_buf ?write_buf
     ?timeout ?stop
-    ?on_exn
+    ?(on_exn=(fun exn -> !Lwt.async_exception_hook exn))
     ?(check_request=check_origin_with_host)
     ?(ctx=Conduit_lwt_unix.default_ctx) ~mode react =
   let module C = Cohttp in
@@ -154,7 +154,7 @@ let establish_server
       Connected_client.create ?read_buf ?write_buf request flow ic oc in
     react client
   in
-  Conduit_lwt_unix.serve ?on_exn ?timeout ?stop ~ctx ~mode begin fun flow ic oc ->
+  Conduit_lwt_unix.serve ~on_exn ?timeout ?stop ~ctx ~mode begin fun flow ic oc ->
     set_tcp_nodelay flow;
     server_fun (Conduit_lwt_unix.endp_of_flow flow) ic oc
   end


### PR DESCRIPTION
I tried to install this from opam but it tried to force me to downgrade `cohttp-lwt-unix` and `conduit-lwt-unix` (see https://github.com/ocaml/opam-repository/pull/14693/files#diff-7f11cf70449495b0ed8dc68f0027e33fR20)

What changed in conduit: https://github.com/mirage/ocaml-conduit/commit/07a1925fc4ff50e5ee7e04afab5f3fb63f22927d#diff-7cb62769efef1a71cd4eb0ec32d355fe

The reason it is not compatible as-is is that the new version of conduit makes the `on_exn` argument mandatory.

This patch fixes that without changing this library's API.