### PR TITLE
Support core and async v0.13

### DIFF
--- a/async/websocket_async.ml
+++ b/async/websocket_async.ml
@@ -17,6 +17,7 @@
 
 open Websocket
 open Core
+open Core.Poly
 open Async
 open Cohttp
 
@@ -185,7 +186,7 @@ let client_ez
       begin fun () ->
         Deferred.any_unit [
           (client ~name ?extra_headers ?random_string ~initialized
-             ~app_to_ws ~ws_to_app ~net_to_ws ~ws_to_net uri |> Deferred.ignore) ;
+             ~app_to_ws ~ws_to_app ~net_to_ws ~ws_to_net uri |> Deferred.ignore_m) ;
           react () ;
           Deferred.all_unit Pipe.[ closed client_read ; closed client_write ; ]
         ]

--- a/async/wscat.ml
+++ b/async/wscat.ml
@@ -62,7 +62,7 @@ let handle_client addr reader writer =
     Logs_async.info ~src begin fun m ->
       m "Incoming connnection request: %a" Cohttp.Request.pp_hum req
     end >>= fun () ->
-    Deferred.return (Cohttp.Request.(uri req |> Uri.path) = "/ws")
+    Deferred.return (String.equal Cohttp.Request.(uri req |> Uri.path) "/ws")
   in
   let rec loop () =
     Pipe.read receiver_read >>= function
@@ -102,7 +102,7 @@ let handle_client addr reader writer =
   Deferred.any [
     begin server
         ~check_request ~app_to_ws ~ws_to_app ~reader ~writer () >>= function
-      | Error err when Error.to_exn err = Exit -> Deferred.unit
+      | Error err when Poly.equal (Error.to_exn err) Exit -> Deferred.unit
       | Error err -> Error.raise err
       | Ok () -> Deferred.unit
     end ;


### PR DESCRIPTION
- Deferred.ignore has been deprecated in favour of Deferred.ignore_m
- opening Core now replaces polymorphic compares with integer compares