### PR TITLE
Move to conduit 4.0.0

### DIFF
--- a/websocket.opam
+++ b/websocket.opam
@@ -14,7 +14,7 @@ depends: [
   "ocaml" {>= "4.06.0"}
   "dune" {>= "1.3.0"}
   "base64" {>= "3.3.0"}
-  "conduit" {>= "2.0.2"}
+  "conduit" {>= "4.0.0"}
   "cohttp" {>= "2.5.1"}
   "ocplib-endian" {>= "1.0"}
   "astring" {>= "0.8.3"}


### PR DESCRIPTION
Conduit 4 is backwards compatible with Conduit 2.

> The new conduit 4.0.0 is backward compatible, no action needed

From and closing #120.