### PR TITLE
Don't close socket on Lwt.Canceled.

### DIFF
--- a/lwt/websocket_lwt_unix.ml
+++ b/lwt/websocket_lwt_unix.ml
@@ -106,7 +106,9 @@ let connect ?(extra_headers = Cohttp.Header.init ())
   >|= fun (ic, oc) ->
   let read_frame = make_read_frame ?buf ~mode:(Client random_string) ic oc in
   let read_frame () =
-    Lwt.catch read_frame (fun exn ->
+    Lwt.catch read_frame (function
+      | Lwt.Canceled as exn -> Lwt.fail exn
+      | exn ->
         Lwt.async (fun () -> Lwt_io.close ic) ;
         Lwt.fail exn ) in
   let buf = Buffer.create 128 in


### PR DESCRIPTION
Hi! I want to write recv code with timeouts like this (just synthetic example):

```
 open Lwt
 
 ...
 let myrecv ~timeout conn =
   let action_th = Websocket_lwt_unix.read conn >>= fun x -> return (Some x) in
   let timeout_th = Lwt_unix.sleep timeout >>= fun () -> return None in
   Lwt.pick [ timeout_th ; action_th ]
   
 ...
 myrecv ~timeout:3.0 >>= function
 | None -> (* TODO: do something else and try again *)
 | Some x -> ...
```

Could you please consider this PR

@vbmithr @paurkedal 