### PR TITLE
fix: don't use Bytes.unsafe_{of,to}_string for not owned strings

### DIFF
--- a/core/websocket.ml
+++ b/core/websocket.ml
@@ -91,7 +91,7 @@ module Frame = struct
     { opcode; extension; final; content }
 
   let of_bytes ?opcode ?extension ?final content =
-    let content = Bytes.unsafe_to_string content in
+    let content = Bytes.to_string content in
     create ?opcode ?extension ?final ~content ()
 
   let close code =
@@ -228,7 +228,7 @@ module Make (IO : Cohttp.S.IO) = struct
   let write_frame_to_buf ~mode buf fr =
     let scratch = Bytes.create 8 in
     let open Frame in
-    let content = Bytes.unsafe_of_string fr.content in
+    let content = Bytes.of_string fr.content in
     let len = Bytes.length content in
     let opcode = Opcode.to_enum fr.opcode in
     let payload_len =
@@ -311,7 +311,7 @@ module Make (IO : Cohttp.S.IO) = struct
         match payload with
         | None -> proto_error "could not read payload (len=%d)" payload_len
         | Some payload ->
-            let payload = Bytes.unsafe_of_string payload in
+            let payload = Bytes.of_string payload in
             if frame_masked then xor mask payload;
             let frame = Frame.of_bytes ~opcode ~extension ~final payload in
             return frame)


### PR DESCRIPTION
`Websocket` module uses `Bytes.unsafe_{of,to}_string` improperly. For example, `write_frame_to_buf`'s argument `fr.content` isn't owned and is modified by `Bytes.set` in `xor`, but `Bytes.unsafe_of_string` is applied to it. That is, when a user calls `write_frame_to_buf`, `fr.content` is unexpectedly modified.

This PR fixes the above issue. As far as I understand, all uses of `Bytes.unsafe_{to,of}_string` are applied to non-owned strings. So this PR fixes them to use the safe counterparts.