### PR TITLE
use mirage-crypto-rng as csprng

### DIFF
--- a/core/dune
+++ b/core/dune
@@ -2,4 +2,4 @@
  (name websocket)
  (public_name websocket)
  (modules sha1 websocket)
- (libraries astring base64 ocplib-endian conduit cohttp))
+ (libraries astring base64 ocplib-endian conduit cohttp mirage-crypto-rng))

--- a/core/websocket.ml
+++ b/core/websocket.ml
@@ -21,8 +21,7 @@ let b64_encoded_sha1sum s = Base64.encode_exn (Sha1.sha_1 s)
 let websocket_uuid = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 module Rng = struct
-  let init ?(state = Random.get_state ()) () len =
-    String.v ~len (fun _ -> Char.of_byte (Random.State.bits state land 0xFF))
+  let init () len = Mirage_crypto_rng.generate len |> Cstruct.to_string
 end
 
 module Frame = struct

--- a/core/websocket.mli
+++ b/core/websocket.mli
@@ -22,7 +22,7 @@ val upgrade_present : Cohttp.Header.t -> bool
 exception Protocol_error of string
 
 module Rng : sig
-  val init : ?state:Random.State.t -> unit -> int -> string
+  val init : unit -> int -> string
   (** [init ?state ()] is a function that returns a string of random
       bytes of length equal to its argument. *)
 end

--- a/dune-project
+++ b/dune-project
@@ -33,7 +33,8 @@
   (conduit (>= 5.1.0))
   (cohttp (>= 5.0.0))
   (ocplib-endian (>= 1.0))
-  (astring (>= 0.8.3))))
+  (astring (>= 0.8.3))
+  mirage-crypto-rng))
 
 (package
  (name websocket-async)

--- a/websocket.opam
+++ b/websocket.opam
@@ -30,6 +30,7 @@ depends: [
   "cohttp" {>= "5.0.0"}
   "ocplib-endian" {>= "1.0"}
   "astring" {>= "0.8.3"}
+  "mirage-crypto-rng"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Currently, `Rng.init () len` always returns the same value:

```
anqou@bokan:~/pievyt/waq/ocaml-websocket$ dune utop
utop # let a = Websocket.Rng.init () 10;;
utop # let b = Websocket.Rng.init () 10;;
utop # string_of_bool (a = b);;
- : string = "true"
```

This PR fixes the above issue by using mirage-crypto-rng.