### PR TITLE
Constraint dependencies of Cohttp and Conduit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build
 **/*.merlin
 *.install
+_opam

--- a/dune-project
+++ b/dune-project
@@ -30,8 +30,8 @@
  (depends
   (ocaml (>= 4.06.0))
   (base64 (>= 3.3.0))
-  (conduit (>= 5.1.0))
-  (cohttp (>= 5.0.0))
+  (conduit (and (>= 5.1.0) (< 7.0.0)))
+  (cohttp (and (>= 5.0.0) (< 6.0.0)))
   (ocplib-endian (>= 1.0))
   (astring (>= 0.8.3))
   (mirage-crypto-rng (>= 1.0.0))))

--- a/websocket.opam
+++ b/websocket.opam
@@ -26,8 +26,8 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.06.0"}
   "base64" {>= "3.3.0"}
-  "conduit" {>= "5.1.0"}
-  "cohttp" {>= "5.0.0"}
+  "conduit" {>= "5.1.0" & < "7.0.0"}
+  "cohttp" {>= "5.0.0" & < "6.0.0"}
   "ocplib-endian" {>= "1.0"}
   "astring" {>= "0.8.3"}
   "mirage-crypto-rng" {>= "1.0.0"}


### PR DESCRIPTION
## Cohttp < 6 otherwise

```
File "lwt/websocket_cohttp_lwt.ml", line 21, characters 32-50:
21 | module Lwt_IO = Websocket.Make (Cohttp_lwt_unix.IO)
                                     ^^^^^^^^^^^^^^^^^^
Error (alert deprecated): module Cohttp_lwt_unix.IO
This module is not for public consumption
...
```

## Conduit < 7 otherwise

```
File "lwt/websocket_lwt_unix.ml", line 198, characters 12-48:
198 |             (Conduit_lwt_unix.endp_of_flow flow)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: This expression has type Conduit_lwt_unix.endp
       but an expression was expected of type Conduit.endp
       The second variant type does not allow tag(s) `TLS_tunnel
```