### PR TITLE
Allow to provide a maximum frame length

### DIFF
--- a/async/websocket_async.mli
+++ b/async/websocket_async.mli
@@ -55,13 +55,14 @@ val server :
   ?name:string ->
   ?check_request:(Cohttp.Request.t -> bool Deferred.t) ->
   ?select_protocol:(string -> string option) ->
+  ?max_frame_length:int ->
   reader:Reader.t ->
   writer:Writer.t ->
   app_to_ws:Frame.t Pipe.Reader.t ->
   ws_to_app:Frame.t Pipe.Writer.t ->
   unit ->
   unit Deferred.Or_error.t
-(** [server ?request_cb reader writer app_to_ws
+(** [server ?request_cb ?max_frame_length reader writer app_to_ws
     ws_to_app ()] returns a thread that expects a websocket client
     connected to [reader]/[writer] and, after performing the
     handshake, will resp. read outgoing frames from [app_to_ws] and
@@ -71,17 +72,19 @@ val server :
     reception of the client HTTP request, [request_cb] will be called
     with the request as its argument. If [request_cb] returns true,
     the connection will proceed, otherwise, the result is immediately
-    determined to [Error Exit]. *)
+    determined to [Error Exit]. If [max_frame_length] is specified and
+    the server receives a frame above this size, the connection is closed. *)
 
 val upgrade_connection :
   ?select_protocol:(string -> string option) ->
   ?ping_interval:Core.Time_ns.Span.t ->
+  ?max_frame_length:int ->
   app_to_ws:Frame.t Pipe.Reader.t ->
   ws_to_app:Frame.t Pipe.Writer.t ->
   f:(unit -> unit Deferred.t) ->
   Cohttp.Request.t ->
   Cohttp.Response.t * (Reader.t -> Writer.t -> unit Deferred.t)
-(** [upgrade_connection ?select_protocol ?ping_interval
+(** [upgrade_connection ?select_protocol ?ping_interval ?max_frame_length
     app_to_ws ws_to_app f request] returns a {!Cohttp_async.Server.response_action}.
 
     Just wrap the return value of this function with [`Expert].

--- a/core/websocket.mli
+++ b/core/websocket.mli
@@ -84,6 +84,7 @@ module type S = sig
   type mode = Client of (int -> string) | Server
 
   val make_read_frame :
+    ?max_len:int ->
     ?buf:Buffer.t -> mode:mode -> IO.ic -> IO.oc -> unit -> Frame.t IO.t
 
   val write_frame_to_buf : mode:mode -> Buffer.t -> Frame.t -> unit
@@ -106,6 +107,7 @@ module type S = sig
     type t
 
     val create :
+      ?max_len:int ->
       ?read_buf:Buffer.t ->
       ?write_buf:Buffer.t ->
       Cohttp.Request.t ->

--- a/lwt/websocket_cohttp_lwt.mli
+++ b/lwt/websocket_cohttp_lwt.mli
@@ -19,6 +19,7 @@
 open Websocket
 
 val upgrade_connection :
+  ?max_frame_length:int ->
   Cohttp.Request.t ->
   (Frame.t -> unit) ->
   (Cohttp_lwt_unix.Server.response_action * (Frame.t option -> unit)) Lwt.t

--- a/lwt/websocket_lwt_unix.mli
+++ b/lwt/websocket_lwt_unix.mli
@@ -39,6 +39,7 @@ val close_transport : conn -> unit Lwt.t
 
 val connect :
   ?extra_headers:Cohttp.Header.t ->
+  ?max_frame_length:int ->
   ?random_string:(int -> string) ->
   ?ctx:Conduit_lwt_unix.ctx ->
   ?buf:Buffer.t ->
@@ -47,6 +48,7 @@ val connect :
   conn Lwt.t
 
 val establish_server :
+  ?max_frame_length:int ->
   ?read_buf:Buffer.t ->
   ?write_buf:Buffer.t ->
   ?timeout:int ->
@@ -71,6 +73,7 @@ val mk_frame_stream :
     is received, the stream will be closed. *)
 
 val establish_standard_server :
+  ?max_frame_length:int ->
   ?read_buf:Buffer.t ->
   ?write_buf:Buffer.t ->
   ?timeout:int ->


### PR DESCRIPTION
This MR allows to provide a maximum frame length when starting a server. There is no maximum by default.

When a frame whose size is above this limit is received, the connection is closed (with the dedicated code `1009`, see https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1).

While this check can be performed on the application side, doing it in the library allows to avoid being attacked by not even reading the frame and allocating memory.