### PR TITLE
Answer to a ping frame is a pong frame with the same content

### DIFF
--- a/async/websocket_async.ml
+++ b/async/websocket_async.ml
@@ -153,7 +153,8 @@ let client_ez ?opcode ?(name = "websocket.client_ez") ?extra_headers ?heartbeat
     Logs_async.debug ~src (fun m -> m "<- %a" Frame.pp fr) >>= fun () ->
     match fr.opcode with
     | Opcode.Ping ->
-        Pipe.write w @@ Frame.create ~opcode:Opcode.Pong () >>| fun () -> None
+        Pipe.write w @@ Frame.create ~opcode:Opcode.Pong () ~content:fr.content
+        >>| fun () -> None
     | Opcode.Close ->
         (* Immediately echo and pass this last message to the user *)
         (if String.length fr.content >= 2 then

--- a/core/websocket.ml
+++ b/core/websocket.ml
@@ -364,8 +364,10 @@ module Make (IO : Cohttp.S.IO) = struct
       t.read_frame () >>= fun fr ->
       match fr.Frame.opcode with
       | Frame.Opcode.Ping ->
-          send t @@ Frame.create ~opcode:Frame.Opcode.Pong () >>= fun () ->
-          return fr
+          (* Ping frames must be answered by pong frame with the same content. *)
+          send t @@
+          Frame.create ~opcode:Frame.Opcode.Pong ~content:fr.content ()
+          >>= fun () -> return fr
       | Frame.Opcode.Close ->
           (* Immediately echo and pass this last message to the user *)
           (if String.length fr.Frame.content >= 2 then

--- a/lwt/wscat.ml
+++ b/lwt/wscat.ml
@@ -12,8 +12,8 @@ let client uri =
   let close_sent = ref false in
   let rec react () =
     Websocket_lwt_unix.read conn >>= function
-    | { Frame.opcode = Ping; _ } ->
-        write conn (Frame.create ~opcode:Pong ()) >>= react
+    | { Frame.opcode = Ping; content; _ } ->
+        write conn (Frame.create ~opcode:Pong ~content ()) >>= react
     | { opcode = Close; content; _ } ->
         (* Immediately echo and pass this last message to the user *)
         (if !close_sent then Lwt.return_unit


### PR DESCRIPTION
[WebSocket specs](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3) specifies that:

> A Pong frame sent in response to a Ping frame must have identical
>  "Application data" as found in the message body of the Ping frame
>  being replied to.

This MR makes the helpers offered by this library follow this.