### PR TITLE
Allow to attach reasons to close frames

### DIFF
--- a/core/websocket.ml
+++ b/core/websocket.ml
@@ -93,8 +93,12 @@ module Frame = struct
     let content = Bytes.to_string content in
     create ?opcode ?extension ?final ~content ()
 
-  let close code =
-    let content = Bytes.create 2 in
+  let close ?reason code =
+    let content = match reason with
+    | None -> Bytes.create 2
+    | Some reason -> Bytes.init (String.length reason + 2) @@ fun i ->
+        if i <= 1 then '\000' else reason.[i - 2]
+    in
     EndianBytes.BigEndian.set_int16 content 0 code;
     of_bytes ~opcode:Opcode.Close content
 end

--- a/core/websocket.mli
+++ b/core/websocket.mli
@@ -61,7 +61,9 @@ module Frame : sig
     unit ->
     t
 
-  val close : int -> t
+  (** [close ?reason code] returns a close frame with status [code]
+      and an optional [reason]. *)
+  val close : ?reason:string -> int -> t
 end
 
 val check_origin :


### PR DESCRIPTION
This MR allows applications to attach a reason when sending a close frame, as per https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.1.

Note that we could add reasons for the various cases in which the library closes the connection.