### PR TITLE
Cohttp: Allow to add a handler to catch asynchronous IO exceptions

### DIFF
--- a/lwt/websocket_cohttp_lwt.mli
+++ b/lwt/websocket_cohttp_lwt.mli
@@ -20,6 +20,7 @@ open Websocket
 
 val upgrade_connection :
   Cohttp.Request.t ->
+  ?io_error_handler:(exn -> unit Lwt.t) ->
   (Frame.t -> unit) ->
   (Cohttp_lwt_unix.Server.response_action * (Frame.t option -> unit)) Lwt.t
 (** [upgrade_connection req incoming_handler] takes [req], a


### PR DESCRIPTION
This is necessary to properly detect closed connections with the way [Resto](https://gitlab.com/tezos/tezos/-/tree/master/resto) uses Cohttp. Resto is used by the [Tezos](https://gitlab.com/tezos/tezos) project.